### PR TITLE
Add max 3 attempts retry loop to next-auth's react fetchData.

### DIFF
--- a/packages/next-auth/src/lib/client.ts
+++ b/packages/next-auth/src/lib/client.ts
@@ -1,9 +1,9 @@
 "use client"
 
-import * as React from "react"
+import { AuthError } from "@auth/core/errors"
 import type { ProviderId, ProviderType } from "@auth/core/providers"
 import type { LoggerInstance, Session } from "@auth/core/types"
-import { AuthError } from "@auth/core/errors"
+import * as React from "react"
 
 /** @todo */
 class ClientFetchError extends AuthError {}
@@ -136,6 +136,7 @@ export interface SessionProviderProps {
  * pages *and* in _app.js.
  * @internal
  */
+const MAX_ATTEMPTS = 3
 export async function fetchData<T = any>(
   path: string,
   __NEXTAUTH: AuthClientConfig,
@@ -143,27 +144,39 @@ export async function fetchData<T = any>(
   req: any = {}
 ): Promise<T | null> {
   const url = `${apiBaseUrl(__NEXTAUTH)}/${path}`
-  try {
-    const options: RequestInit = {
-      headers: {
-        "Content-Type": "application/json",
-        ...(req?.headers?.cookie ? { cookie: req.headers.cookie } : {}),
-      },
-    }
+  let attempts = 0
+  while (attempts < MAX_ATTEMPTS) {
+    try {
+      const options: RequestInit = {
+        headers: {
+          "Content-Type": "application/json",
+          ...(req?.headers?.cookie ? { cookie: req.headers.cookie } : {}),
+        },
+      }
 
-    if (req?.body) {
-      options.body = JSON.stringify(req.body)
-      options.method = "POST"
-    }
+      if (req?.body) {
+        options.body = JSON.stringify(req.body)
+        options.method = "POST"
+      }
 
-    const res = await fetch(url, options)
-    const data = await res.json()
-    if (!res.ok) throw data
-    return data
-  } catch (error) {
-    logger.error(new ClientFetchError((error as Error).message, error as any))
-    return null
+      const res = await fetch(url, options)
+      const data = await res.json()
+      if (!res.ok) throw data
+      return data
+    } catch (error) {
+      attempts++
+      if (attempts === MAX_ATTEMPTS) {
+        logger.error(
+          new ClientFetchError((error as Error).message, error as any)
+        )
+        throw error
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.pow(2, attempts) * 100)
+      )
+    }
   }
+  return null
 }
 
 /** @internal */


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

- Adds max 3 attempts retry loop to `/next-auth/src/lib/cllient:fetchData`.
- Adds `throw error`, instead of log and `return null`, to `/next-auth/src/lib/cllient:fetchData`.


## 🧢 Checklist

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
